### PR TITLE
Remove is_deleted

### DIFF
--- a/ndn_hydra/repo/group_messages/remove.py
+++ b/ndn_hydra/repo/group_messages/remove.py
@@ -36,7 +36,7 @@ class RemoveMessage(SpecificMessage):
 
         self.logger.info(f"[MSG][REMOVE]   fil={file_name}")
         file = global_view.get_file(file_name)
-        if (file == None) or (file['is_deleted'] == True):
+        if not file:
             self.logger.warning('nothing to remove')
         else:
             # Delete from global view

--- a/ndn_hydra/repo/group_messages/store.py
+++ b/ndn_hydra/repo/group_messages/store.py
@@ -33,7 +33,7 @@ class StoreMessage(SpecificMessage):
 
         self.logger.info(f"[MSG][STORE]    nam={node_name};fil={file_name}")
         file = global_view.get_file(file_name)
-        if (file == None) or (file['is_deleted'] == True):
+        if not file:
             self.logger.warning('add to pending store')
             global_view.add_pending_store(file_name, node_name)
         else:

--- a/ndn_hydra/repo/group_messages/update.py
+++ b/ndn_hydra/repo/group_messages/update.py
@@ -37,7 +37,7 @@ class UpdateMessage(SpecificMessage):
 
         self.logger.info(f"[MSG][UPDATE]   fil={file_name}")
         file = global_view.get_file(file_name)
-        if (file == None) or (file['is_deleted'] == True):
+        if not file:
             self.logger.warning('nothing to update')
         else:
             global_view.update_file(file_name, expiration_time)

--- a/ndn_hydra/repo/handles/read_handle.py
+++ b/ndn_hydra/repo/handles/read_handle.py
@@ -128,7 +128,7 @@ class ReadHandle(object):
         if file_name == None:
             return None
         on_list = file_info["stores"]
-        if file_info["is_deleted"] == True or not on_list:
+        if not on_list:
             return None
         if self.node_name in on_list:
             return self.node_name

--- a/ndn_hydra/repo/modules/file_fetcher.py
+++ b/ndn_hydra/repo/modules/file_fetcher.py
@@ -55,8 +55,8 @@ class FileFetcher:
         # Randomly select a node to fetch file from
         file_info = self.global_view.get_file(file_name)
         on_list = file_info["stores"]
-        if file_info["is_deleted"] == True or not on_list:
-            self.logger.info("FileFetcher: File is deleted or not in stores")
+        if not on_list:
+            self.logger.info("FileFetcher: File not in stores")
             return
         active_nodes = set([node['node_name'] for node in self.global_view.get_nodes()])
         on_list = [x for x in on_list if x in active_nodes]

--- a/ndn_hydra/repo/modules/file_remover.py
+++ b/ndn_hydra/repo/modules/file_remover.py
@@ -1,5 +1,3 @@
-import os
-
 # Responsible for removing data from the data storage 
 # from all associated nodes
 def remove_file(config, data_storage, file):


### PR DESCRIPTION
The `is_deleted` db field is removed and we directly delete the row from the db if a file is deleted and thus do not maintain the flag anymore. This was primarily done to avoid maintaining the flag when a new file with the same name as a deleted file is inserted.