### PR TITLE
Refetch first segment if a link, fix progress count

### DIFF
--- a/ndn_hydra/client/functions/fetch.py
+++ b/ndn_hydra/client/functions/fetch.py
@@ -62,19 +62,18 @@ class HydraFetchClient(object):
         if meta_info.content_type == ContentType.NACK:
             print("Distributed Repo does not have that file.")
             return
-        elif meta_info.content_type == ContentType.LINK:
+
+        if meta_info.content_type == ContentType.LINK:
             print(f"First Packet Content: {bytes(content).decode()}")
             # name_at_repo = Name.from_str(bytes(content).decode())
-            end_index = Component.to_number(meta_info.final_block_id)
             forwarding_hint = [(1, bytes(content).decode())]
-        else:
-            # print(type(content))
-            # name_at_repo = name_at_repo[:-1]
-            start_index = start_index + 1
-            end_index = Component.to_number(meta_info.final_block_id)
+        # else:
+        #     # name_at_repo = name_at_repo[:-1]
+        #     # start_index = start_index + 1
+        #     # print(name_at_repo)
+        #     b_array.extend(content)
 
-            # print(name_at_repo)
-            b_array.extend(content)
+        end_index = Component.to_number(meta_info.final_block_id)
 
         # print(Name.to_str(data_name))
 

--- a/ndn_hydra/client/functions/insert.py
+++ b/ndn_hydra/client/functions/insert.py
@@ -62,12 +62,12 @@ class HydraInsertClient(object):
             final_block_id = Component.from_segment(seg_cnt - 1)
             inner_packets = [self.app.prepare_data(packet_prefix + [Component.from_segment(i)],
                                                   data[i * SEGMENT_SIZE:(i + 1) * SEGMENT_SIZE],
-                                                  freshness_period=10000,
+                                                  freshness_period=0,
                                                   final_block_id=final_block_id)
                             for i in range(seg_cnt)]
             self.packets = [self.app.prepare_data(publish_prefix + [Component.from_segment(i)],
                                                     packet,
-                                                    freshness_period=10000,
+                                                    freshness_period=0,
                                                     final_block_id=final_block_id)
                             for i, packet in enumerate(inner_packets)]
 

--- a/ndn_hydra/repo/handles/read_handle.py
+++ b/ndn_hydra/repo/handles/read_handle.py
@@ -78,7 +78,7 @@ class ReadHandle(object):
         best_id = self._best_id_for_file(file_name)
         segment_comp = "/" + Component.to_str(int_name[-1])
 
-        if int_param.must_be_fresh:
+        if int_param.must_be_fresh and segment_comp != "/seg=0":
             return
 
         if best_id is None:


### PR DESCRIPTION
1. If the first packet was a link, we need to make sure we re-fetch the first packet (and not from cache)
2. Fix counter of progress bar to be uniform.