### PR TITLE
Fix packet caching issue with link and data packets

### DIFF
--- a/ndn_hydra/client/functions/insert.py
+++ b/ndn_hydra/client/functions/insert.py
@@ -48,9 +48,7 @@ class HydraInsertClient(object):
         query_client = HydraQueryClient(self.app, self.client_prefix, self.repo_prefix)
         query = [Component.from_str("file")] + file_name
         query_result = await query_client.send_query(query)
-        target_file_name = Name.to_str(query)[5:]
-
-        if query_result == target_file_name:
+        if query_result:
             print('File already exists, aborted insertion.')
             return False
 
@@ -62,12 +60,12 @@ class HydraInsertClient(object):
             final_block_id = Component.from_segment(seg_cnt - 1)
             inner_packets = [self.app.prepare_data(packet_prefix + [Component.from_segment(i)],
                                                   data[i * SEGMENT_SIZE:(i + 1) * SEGMENT_SIZE],
-                                                  freshness_period=2000,
+                                                  freshness_period=10000,
                                                   final_block_id=final_block_id)
                             for i in range(seg_cnt)]
             self.packets = [self.app.prepare_data(publish_prefix + [Component.from_segment(i)],
                                                     packet,
-                                                    freshness_period=2000,
+                                                    freshness_period=10000,
                                                     final_block_id=final_block_id)
                             for i, packet in enumerate(inner_packets)]
 

--- a/ndn_hydra/client/functions/query.py
+++ b/ndn_hydra/client/functions/query.py
@@ -8,6 +8,7 @@
 #  @Pip-Library:   https://pypi.org/project/ndn-hydra
 # -------------------------------------------------------------
 
+import json
 import logging
 from ndn.app import NDNApp
 from ndn.encoding import FormalName, Component, Name, ContentType
@@ -64,11 +65,11 @@ class HydraQueryClient(object):
                         print(f'No files inserted in the remote repo.')
                 elif querytype == "file":
                     if content:
-                        file = File.parse(content)
+                        file = json.loads(content.tobytes().decode())
                         print(f'File meta-info:')
-                        print(f'\tfile_name: {Name.to_str(file.file_name)}')
-                        print(f'\tsize: {file.size} | packets: {file.packets} | packet_size: {file.packet_size}')
-                        return Name.to_str(file.file_name)
+                        print(f'\tfile_name: {file["file_name"]}')
+                        print(f'\tsize: {file["size"]} | packets: {file["packets"]} | packet_size: {file["packet_size"]}')
+                        return file
                 elif querytype == "prefix":
                     filelist = FileList.parse(content)
                     counter = 1


### PR DESCRIPTION
This fixes the packet caching issue with link and data packets.

The issue was we were expressing same interest which was fulfilled with either a link or data packet. This packet would be cached by NFD.

We are now requesting the information carried by the link packet via a different NDN interest altogether, thus the data packet will have a separate interest, and the cached response won't be an issue.